### PR TITLE
feat: add cross-platform matrix-sort-i18n utility

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
         "matrix-gen-i18n": "scripts/gen-i18n.cjs",
         "matrix-compare-i18n-files": "scripts/compare-file.cjs",
         "matrix-i18n-rekey": "scripts/rekey.cjs",
-        "matrix-i18n-lint": "scripts/lint-i18n.cjs"
+        "matrix-i18n-lint": "scripts/lint-i18n.cjs",
+        "matrix-sort-i18n": "scripts/sort-json.cjs"
     },
     "scripts": {
         "build:ts": "tsc",

--- a/scripts/sort-json.cts
+++ b/scripts/sort-json.cts
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 New Vector Ltd
+Copyright 2026 Aditya Cherukuru
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/scripts/sort-json.cts
+++ b/scripts/sort-json.cts
@@ -1,0 +1,97 @@
+/*
+Copyright 2026 New Vector Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * Cross-platform JSON key sorting utility.
+ * Replaces the need for `jq --sort-keys` which has issues on Windows due to:
+ * - jq not being installed by default
+ * - Shell quoting differences ('.' vs ".")
+ *
+ * Usage: matrix-sort-i18n <file.json> [file2.json ...]
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+
+/**
+ * Recursively sorts the keys of an object alphabetically.
+ * Arrays are preserved as-is (not sorted), but objects within arrays are sorted.
+ */
+function sortObjectKeys(obj: unknown): unknown {
+    if (obj === null || typeof obj !== "object") {
+        return obj;
+    }
+
+    if (Array.isArray(obj)) {
+        return obj.map(sortObjectKeys);
+    }
+
+    const sortedObj: Record<string, unknown> = {};
+    const keys = Object.keys(obj as Record<string, unknown>).sort();
+    for (const key of keys) {
+        sortedObj[key] = sortObjectKeys((obj as Record<string, unknown>)[key]);
+    }
+    return sortedObj;
+}
+
+/**
+ * Sorts JSON file keys and writes back to the same file.
+ */
+function sortJsonFile(filePath: string): void {
+    const absolutePath = path.resolve(filePath);
+
+    if (!fs.existsSync(absolutePath)) {
+        throw new Error(`File not found: ${absolutePath}`);
+    }
+
+    const content = fs.readFileSync(absolutePath, "utf8");
+    let parsed: unknown;
+
+    try {
+        parsed = JSON.parse(content);
+    } catch (e) {
+        throw new Error(`Invalid JSON in file: ${absolutePath}`);
+    }
+
+    const sorted = sortObjectKeys(parsed);
+    const output = JSON.stringify(sorted, null, 4) + "\n";
+
+    fs.writeFileSync(absolutePath, output, "utf8");
+    console.log(`Sorted keys in: ${filePath}`);
+}
+
+// Main execution
+if (process.argv.length < 3) {
+    console.error("Usage: matrix-sort-i18n <file.json> [file2.json ...]");
+    console.error("Sorts JSON object keys alphabetically in-place.");
+    process.exit(1);
+}
+
+const files = process.argv.slice(2);
+let hasError = false;
+
+for (const file of files) {
+    try {
+        sortJsonFile(file);
+    } catch (e) {
+        console.error(`Error processing ${file}:`, (e as Error).message);
+        hasError = true;
+    }
+}
+
+if (hasError) {
+    process.exit(1);
+}


### PR DESCRIPTION
Adds a new `matrix-sort-i18n` CLI command that sorts JSON object keys alphabetically in-place. This provides a cross-platform alternative to the `jq --sort-keys` command currently used in element-web and element-desktop i18n scripts.

## Problem

The current i18n:sort scripts in element-web and element-desktop use:
```
jq --sort-keys '.' file.json > file.json.tmp && mv file.json.tmp file.json
```

This has several issues on Windows:
1. `jq` is not installed by default and must be manually installed
2. Single quotes ('.' ) don't work in PowerShell - causes syntax errors
3. The `mv` command may behave differently across shells

## Solution

This PR adds a native Node.js script that:
- Reads JSON file(s) passed as arguments
- Recursively sorts all object keys alphabetically
- Writes the sorted JSON back to the same file
- Works consistently on Windows, macOS, and Linux

## Usage

After this change, element-web and element-desktop can update their package.json scripts from:
```json
"i18n:sort": "jq --sort-keys '.' src/i18n/strings/en_EN.json > ..."
```
to:
```json
"i18n:sort": "matrix-sort-i18n src/i18n/strings/en_EN.json"
```

Fixes element-hq/element-web#31630